### PR TITLE
Add "dry" cli option; e.g. for tuning the reward mechanism; deploy more tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,22 @@ Given a set of Machine Learning models with trending scores and hosting costs, d
 
 ### Sample Usage
 
-```python
+```bash
 python cli.py --max-models-per-task 300 --budget 10000 --filename "selected_models" --dry
 ```
 
 ```
-2025-03-28 16:04:44 - Selected models: 381 out of 1720 models
-2025-03-28 16:04:44 - Expected spent budget: 9984 out of 10000                                                                                               
-2025-03-28 16:04:44 - Maximum reward reached: 695
+2025-04-23 15:27:18 - Selected models: 391 out of 2021 candidate models
+2025-04-23 15:27:18 - Expected spent budget: $9,984 out of $10,000                                                                                                                           
+2025-04-23 15:27:18 - Maximum reward reached: 2063
+2025-04-23 15:27:18 - Models per task:
+{'feature-extraction': 69,
+ 'fill-mask': 99,
+ 'sentence-similarity': 67,
+ 'text-classification': 86,
+ 'token-classification': 33,
+ 'translation': 26,
+ 'zero-shot-classification': 11}
+2025-04-23 15:27:34 - Selected 391 models with total reward of 2063
+2025-04-23 15:27:34 - Spent budget: $9,984 out of $10,000
 ```

--- a/README.md
+++ b/README.md
@@ -19,17 +19,25 @@ python cli.py --max-models-per-task 300 --budget 10000 --filename "selected_mode
 ```
 
 ```
-2025-04-23 15:27:18 - Selected models: 391 out of 2021 candidate models
-2025-04-23 15:27:18 - Expected spent budget: $9,984 out of $10,000                                                                                                                           
-2025-04-23 15:27:18 - Maximum reward reached: 2063
-2025-04-23 15:27:18 - Models per task:
-{'feature-extraction': 69,
+2025-04-23 15:54:38 - Selected models: 389 out of 4211 candidate models
+2025-04-23 15:54:38 - Expected spent budget: $9,985 out of $10,000
+2025-04-23 15:54:38 - Maximum reward reached: 2239
+2025-04-23 15:54:38 - Models per task:
+{'audio-classification': 6,
+ 'automatic-speech-recognition': 16,
+ 'feature-extraction': 54,
  'fill-mask': 99,
- 'sentence-similarity': 67,
- 'text-classification': 86,
- 'token-classification': 33,
- 'translation': 26,
- 'zero-shot-classification': 11}
-2025-04-23 15:27:34 - Selected 391 models with total reward of 2063
-2025-04-23 15:27:34 - Spent budget: $9,984 out of $10,000
+ 'image-classification': 29,
+ 'image-segmentation': 17,
+ 'object-detection': 12,
+ 'question-answering': 10,
+ 'sentence-similarity': 65,
+ 'summarization': 6,
+ 'table-question-answering': 1,
+ 'text-classification': 47,
+ 'token-classification': 10,
+ 'translation': 13,
+ 'zero-shot-classification': 4}
+2025-04-23 15:54:38 - Selected 389 models with total reward of 2239
+2025-04-23 15:54:38 - Spent budget: $9,985 out of $10,000
 ```

--- a/README.md
+++ b/README.md
@@ -12,22 +12,10 @@ Given a set of Machine Learning models with trending scores and hosting costs, d
 
 **Goal:** Solve the [0/1 Knapsack optimization problem](https://en.wikipedia.org/wiki/Knapsack_problem#0-1_knapsack_problem) to maximize total reward while staying within the budget.
 
-### Sample Output:
+### Sample Usage
 
 ```python
-trending = Trending(
-    tasks=[
-        "feature-extraction",
-        "sentence-similarity",
-        "fill-mask",
-        "token-classification",
-        "text-classification",
-        "zero-shot-classification",
-    ],
-    max_models_per_task=300,
-    budget=10_000,
-)
-selected_models, max_reward, spent_budget = trending(filename="selected_models.json")
+python cli.py --max-models-per-task 300 --budget 10000 --filename "selected_models" --dry
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Given a set of Machine Learning models with trending scores and hosting costs, d
 ### Sample Usage
 
 ```bash
-python cli.py --max-models-per-task 300 --budget 10000 --filename "selected_models" --dry
+python cli.py --max-models-per-task 300 --budget 10000 --filename "selected_models.json" --dry
 ```
 
 ```

--- a/cli.py
+++ b/cli.py
@@ -32,6 +32,11 @@ def parse_args():
         help="Path to save selected models as JSON. If not provided, models won't be saved to file."
     )
     parser.add_argument(
+        "--dry",
+        action="store_true",
+        help="Run in dry run mode. No models will be deployed."
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose output"
@@ -57,7 +62,7 @@ def main():
     )
 
     # Run the trending model selection and deployment
-    selected_models, max_reward, spent_budget = trending(filename=args.filename)
+    selected_models, max_reward, spent_budget = trending(filename=args.filename, deploy_models=not args.dry)
 
     logging.info(f"Selected {len(selected_models)} models with total reward of {max_reward}")
     logging.info(f"Spent budget: ${spent_budget:,} out of ${args.budget:,}")

--- a/trending_deploy/constants.py
+++ b/trending_deploy/constants.py
@@ -18,16 +18,49 @@ class Model:
     def to_dict(self):
         return asdict(self)
 
-# Text only for now, we can extend to vision and beyond as well
-DEFAULT_TASKS = [
+# Based on https://github.com/huggingface/hub-docs/tree/main/docs/inference-providers/tasks
+ALL_TASKS = [
+    # Audio
+    "audio-classification",
+    "automatic-speech-recognition",
+
+    # Image
+    "image-classification",
+    "image-segmentation",
+    "image-to-image",
+    "object-detection",
+    "text-to-image",
+
+    # Video
+    "text-to-video",
+
+    # Text
     "feature-extraction",
-    "sentence-similarity",
     "fill-mask",
-    "token-classification",
+    "sentence-similarity",
+    "question-answering",
+    "summarization",
     "text-classification",
-    "zero-shot-classification",
+    "text-generation",
+    "text-ranking",
+    "token-classification",
     "translation",
-    # "text-ranking", # A good candidate, but not yet available to Deploy
+    "zero-shot-classification",
+
+    # Table
+    "table-question-answering",
+]
+GPU_ONLY_TASKS = [
+    "image-to-image",
+    "text-to-image",
+    "text-to-video",
+    "text-generation",
+]
+NOT_IMPLEMENTED_TASKS = [
+    "text-ranking",
+]
+DEFAULT_TASKS = [
+    task for task in ALL_TASKS if task not in (GPU_ONLY_TASKS + NOT_IMPLEMENTED_TASKS)
 ]
 
 # Just AWS for now

--- a/trending_deploy/constants.py
+++ b/trending_deploy/constants.py
@@ -55,6 +55,8 @@ GPU_ONLY_TASKS = [
     "text-to-image",
     "text-to-video",
     "text-generation",
+    "automatic-speech-recognition",
+    "object-detection",
 ]
 NOT_IMPLEMENTED_TASKS = [
     "text-ranking",

--- a/trending_deploy/main.py
+++ b/trending_deploy/main.py
@@ -28,7 +28,7 @@ class Trending():
         self.max_models_per_task = max_models_per_task
         self.budget = budget
 
-    def __call__(self, budget: int | None = None, filename: str | Path | None = None):
+    def __call__(self, budget: int | None = None, filename: str | Path | None = None, deploy_models: bool = True):
         # Step 1: Load the trending models as model candidates
         model_candidates: list[Model] = trending_models(tasks=self.tasks, max_models_per_task=self.max_models_per_task)
 
@@ -56,16 +56,17 @@ class Trending():
             with open(filename, "w") as f:
                 json.dump([model.to_dict() for model in selected_models], f, indent=4, default=str)
 
-        # Step 4: Deploy the selected models
-        results = deploy_selected_models(selected_models)
+        if deploy_models:
+            # Step 4: Deploy the selected models
+            results = deploy_selected_models(selected_models)
 
-        logging.debug(f"Deployed models: {results['deployed_success']}")
-        logging.warning(f"Failed to deploy models: {results['deployed_failed']}")
-        logging.debug(f"Models already deployed: {results['undeployed_success']}")
-        logging.warning(f"Failed to undeploy models: {results['undeployed_failed']}")
+            logging.debug(f"Deployed models: {results['deployed_success']}")
+            logging.warning(f"Failed to deploy models: {results['deployed_failed']}")
+            logging.debug(f"Models already deployed: {results['undeployed_success']}")
+            logging.warning(f"Failed to undeploy models: {results['undeployed_failed']}")
 
         return selected_models, max_reward, spent_budget
 
 if __name__ == "__main__":
     trending = Trending(tasks=DEFAULT_TASKS, max_models_per_task=300, budget=10_000)
-    selected_models, max_reward, spent_budget = trending(filename="selected_models.json")
+    selected_models, max_reward, spent_budget = trending(filename="selected_models.json", deploy_models=False)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add "dry" cli option
* Deploy many more task types

## Details
The dry option will be useful for tuning the reward mechanism, as the current one is not necessarily perfect or final.

Beyond that, we now deploy most task types, except the ones that are usually GPU-based like image-to-image, text-to-image, text-to-video, and text-generation.

- Tom Aarsen